### PR TITLE
Journalctl optimize scripts

### DIFF
--- a/1-oci/scripts/check.sh
+++ b/1-oci/scripts/check.sh
@@ -712,10 +712,6 @@ get_component_versions() {
     local containerd_version=$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.containerRuntimeVersion}')
     echo -e "Container Runtime: ${GREEN}$containerd_version${NC}"
             
-    # Get local-path-provisioner version
-    local local_path_version=$(kubectl -n kube-system get deployment local-path-provisioner -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null | cut -d: -f2 || echo "Not found")
-    echo -e "Local-Path-Provisioner Version: ${GREEN}$local_path_version${NC}"
-    
     # Get metrics-server version
     local metrics_server_version=$(kubectl -n kube-system get deployment metrics-server -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null | cut -d: -f2 || echo "Not found")
     echo -e "Metrics-Server Version: ${GREEN}$metrics_server_version${NC}"

--- a/1-oci/scripts/k3s-install-agent.sh
+++ b/1-oci/scripts/k3s-install-agent.sh
@@ -39,6 +39,9 @@ setup_system() {
       log "ERROR" "apt-get install failed: $(DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends apt-utils software-properties-common jq python3 open-iscsi curl util-linux 2>&1)"
       exit 1
     fi
+    
+    apt-get clean
+    rm -rf /var/lib/apt/lists/*
 
     cat > /etc/systemd/journald.conf <<EOF
 SystemMaxUse=$${JOURNAL_MAX_SIZE}

--- a/1-oci/scripts/k3s-install-agent.sh
+++ b/1-oci/scripts/k3s-install-agent.sh
@@ -21,37 +21,41 @@ cleanup() {
 
 setup_system() {
     log "INFO" "Setting up system requirements"
-    
-    systemctl stop netfilter-persistent.service
-    systemctl disable netfilter-persistent.service
-    /usr/sbin/netfilter-persistent flush
-    
-    apt-get update && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
-    apt-get install -y software-properties-common jq
-    
+
+    /usr/sbin/netfilter-persistent flush || true
+    systemctl stop netfilter-persistent.service || true
+    systemctl disable netfilter-persistent.service || true
+
+    apt-get update
+    if ! DEBIAN_FRONTEND=noninteractive apt-get upgrade -y; then
+       log "ERROR" "apt-get upgrade failed: $(DEBIAN_FRONTEND=noninteractive apt-get upgrade -y 2>&1)"
+       exit 1
+    fi
+
+    if ! DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        apt-utils software-properties-common jq python3 python3-full \
+        python3-venv open-iscsi curl util-linux; then
+
+      log "ERROR" "apt-get install failed: $(DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends apt-utils software-properties-common jq python3 open-iscsi curl util-linux 2>&1)"
+      exit 1
+    fi
+
     cat > /etc/systemd/journald.conf <<EOF
 SystemMaxUse=$${JOURNAL_MAX_SIZE}
 SystemMaxFileSize=$${JOURNAL_MAX_SIZE}
 EOF
     systemctl restart systemd-journald
-}
 
-install_oci_cli() {
-    log "INFO" "Installing OCI CLI"
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
-        python3 python3-full nginx python3-venv
-        
-    python3 -m venv /opt/oci-cli-venv
-    /opt/oci-cli-venv/bin/pip install oci-cli
-    ln -sf /opt/oci-cli-venv/bin/oci /usr/local/bin/oci
+    systemctl enable --now iscsid.service
 }
 
 wait_for_api_server() {
     log "INFO" "Waiting for K3s API server"
     until curl --output /dev/null --silent -k https://${k3s_url}:6443; do
-        log "INFO" "Waiting for API server..."
+        log "INFO" "API server not yet available, waiting 5 seconds..."
         sleep 5
     done
+    log "INFO" "K3s API server is responsive."
 }
 
 install_k3s() {
@@ -75,20 +79,11 @@ install_k3s() {
     done
 }
 
-setup_longhorn() {
-    log "INFO" "Setting up Longhorn requirements"
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
-        open-iscsi curl util-linux
-    systemctl enable --now iscsid.service
-}
-
 main() {
     log "INFO" "Starting K3s agent installation"
     setup_system
-    install_oci_cli
     wait_for_api_server
     install_k3s
-    setup_longhorn
     log "INFO" "K3s agent installation completed successfully"
 }
 


### PR DESCRIPTION
This pull request includes several changes to the `1-oci/scripts` directory to improve system setup, package management, and K3s installation processes. The most important changes include modifications to the system setup scripts, enhancements to the K3s installation parameters, and cleanup of unnecessary steps.

Improvements to system setup and package management:

* [`1-oci/scripts/k3s-install-agent.sh`](diffhunk://#diff-7e26d7b9f45b7200406636906f5ccddd1bd30e8566714ef39037a57171f0f2f5L25-R61): Enhanced the `setup_system` function to include error handling for package updates and installations, and added steps to clean up the `apt` cache.
* [`1-oci/scripts/k3s-install-server.sh`](diffhunk://#diff-b892df617029d56dd6825adcffa7480c26e53b0891815462ef92c0a17d3db909L186-R188): Modified the `setup_system` function to mask the `netfilter-persistent` service and added steps to clean up the `apt` cache. [[1]](diffhunk://#diff-b892df617029d56dd6825adcffa7480c26e53b0891815462ef92c0a17d3db909L186-R188) [[2]](diffhunk://#diff-b892df617029d56dd6825adcffa7480c26e53b0891815462ef92c0a17d3db909R199-R201)

Enhancements to K3s installation parameters:

* [`1-oci/scripts/k3s-install-server.sh`](diffhunk://#diff-b892df617029d56dd6825adcffa7480c26e53b0891815462ef92c0a17d3db909L236-R240): Updated the `install_k3s` function to include additional parameters for disabling local storage and setting kubeconfig file permissions.

Cleanup and removal of unnecessary steps:

* [`1-oci/scripts/k3s-install-agent.sh`](diffhunk://#diff-7e26d7b9f45b7200406636906f5ccddd1bd30e8566714ef39037a57171f0f2f5L78-L91): Removed the `setup_longhorn` function and its call from the main function.
* [`1-oci/scripts/check.sh`](diffhunk://#diff-8b4bca549c745a03c6bf8f9201eebe1fd38791066798ab7aa8ea5849a954152cL715-L718): Removed the retrieval of the local-path-provisioner version.

- done after analysing journalctl right before install was finished + some other improvements from AI